### PR TITLE
chore: ignore lint errors during build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,14 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+
+  // Ignore TypeScript and ESLint errors during production builds
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   
   // Configuração webpack existente
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- ignore ESLint and TypeScript errors during production builds to prevent deployment failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b5a898a4832ca97c41a309ef68e9