### PR TITLE
feat: add language env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Default language for the application
+NEXT_PUBLIC_DEFAULT_LANGUAGE=pt-BR

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/CONFIGURACAO_IDIOMA.md
+++ b/CONFIGURACAO_IDIOMA.md
@@ -4,15 +4,13 @@ Este projeto implementa um sistema de tradução simples baseado em configuraç�
 
 ## Como Configurar o Idioma
 
-Para alterar o idioma da aplicação, edite o arquivo `src/config/language.ts`:
+Defina o idioma padrão criando um arquivo `.env` na raiz do projeto (ou utilizando `.env.example` como base) e configurando a variável:
 
-```typescript
-// Para usar português (padrão)
-export const CURRENT_LANGUAGE: Language = 'pt-BR';
-
-// Para usar inglês
-export const CURRENT_LANGUAGE: Language = 'en';
 ```
+NEXT_PUBLIC_DEFAULT_LANGUAGE=pt-BR
+```
+
+Altere o valor para `en` para utilizar inglês.
 
 ## Idiomas Disponíveis
 
@@ -32,7 +30,7 @@ export const CURRENT_LANGUAGE: Language = 'en';
 
 ### Como Funciona
 
-1. O idioma é definido na constante `CURRENT_LANGUAGE`
+1. O idioma é definido pela variável de ambiente `NEXT_PUBLIC_DEFAULT_LANGUAGE`
 2. A função `getTranslations()` retorna as traduções do idioma atual
 3. A função `getCurrentLanguage()` retorna o idioma configurado
 4. Os componentes usam essas funções para exibir o conteúdo traduzido
@@ -44,7 +42,7 @@ Para adicionar um novo idioma:
 1. Adicione o código do idioma ao tipo `Language`
 2. Adicione as traduções no objeto `translations`
 3. Adicione as ferramentas traduzidas no objeto `toolsData`
-4. Configure `CURRENT_LANGUAGE` para o novo idioma
+4. Configure `NEXT_PUBLIC_DEFAULT_LANGUAGE` para o novo idioma
 
 ## Vantagens deste Sistema
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { getTranslations } from "@/config/language";
+import { getTranslations, getCurrentLanguage } from "@/config/language";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -11,6 +11,7 @@ const inter = Inter({
 });
 
 const t = getTranslations();
+const lang = getCurrentLanguage();
 
 export const metadata: Metadata = {
   title: t.siteTitle,
@@ -23,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="pt-BR">
+    <html lang={lang}>
       <body className={`${inter.variable} font-sans antialiased`}>
         <Header />
         <main className="flex-1">

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -1,6 +1,11 @@
+const envLanguage =
+  (process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE === 'en'
+    ? 'en'
+    : 'pt-BR') as 'pt-BR' | 'en';
+
 export const LANGUAGE_CONFIG = {
-  defaultLanguage: 'pt-BR',
-  currentLanguage: 'pt-BR' as 'pt-BR' | 'en',
+  defaultLanguage: envLanguage,
+  currentLanguage: envLanguage,
   
   // Idiomas disponíveis
   availableLanguages: {


### PR DESCRIPTION
## Summary
- allow defining app language through NEXT_PUBLIC_DEFAULT_LANGUAGE env
- add example env file and update documentation
- set HTML lang attribute using configured language

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899feb443f0832c91299d61d643328c