### PR TITLE
Add cookie banner and policy pages for AdSense approval

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+  <url>
+    <loc>https://example.com/about</loc>
+  </url>
+  <url>
+    <loc>https://example.com/contact</loc>
+  </url>
+  <url>
+    <loc>https://example.com/privacy-policy</loc>
+  </url>
+  <url>
+    <loc>https://example.com/terms-of-use</loc>
+  </url>
+</urlset>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,11 @@
+import { getTranslations } from '@/config/language';
+
+export default function AboutPage() {
+  const t = getTranslations();
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">{t.about}</h1>
+      <p>Este site oferece diversas ferramentas online gratuitas para facilitar o seu dia a dia.</p>
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,11 @@
+import { getTranslations } from '@/config/language';
+
+export default function ContactPage() {
+  const t = getTranslations();
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">{t.contact}</h1>
+      <p>Entre em contato pelo e-mail <a href="mailto:contato@example.com" className="text-blue-600">contato@example.com</a>.</p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import CookieBanner from "@/components/CookieBanner";
 import { getTranslations, getCurrentLanguage } from "@/config/language";
 
 const inter = Inter({
@@ -31,6 +32,7 @@ export default function RootLayout({
           {children}
         </main>
         <Footer />
+        <CookieBanner />
       </body>
     </html>
   );

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,11 @@
+import { getTranslations } from '@/config/language';
+
+export default function PrivacyPolicyPage() {
+  const t = getTranslations();
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">{t.privacyPolicy}</h1>
+      <p>Esta política de privacidade descreve como suas informações são utilizadas e protegidas ao utilizar este site.</p>
+    </div>
+  );
+}

--- a/src/app/terms-of-use/page.tsx
+++ b/src/app/terms-of-use/page.tsx
@@ -1,0 +1,11 @@
+import { getTranslations } from '@/config/language';
+
+export default function TermsOfUsePage() {
+  const t = getTranslations();
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">{t.termsOfUse}</h1>
+      <p>Ao utilizar este site, você concorda com os termos e condições estabelecidos nesta página.</p>
+    </div>
+  );
+}

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getTranslations } from '@/config/language';
+
+export default function CookieBanner() {
+  const [accepted, setAccepted] = useState(true);
+  const t = getTranslations();
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    setAccepted(consent === 'accepted');
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookie-consent', 'accepted');
+    setAccepted(true);
+  };
+
+  if (accepted) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 bg-gray-900 text-white p-4 flex flex-col md:flex-row md:items-center md:justify-between space-y-2 md:space-y-0 z-50">
+      <p className="text-sm">{t.cookieMessage}</p>
+      <button
+        onClick={acceptCookies}
+        className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        {t.acceptCookies}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { getTranslations } from '@/config/language';
 
 export default function Footer() {
@@ -6,11 +7,28 @@ export default function Footer() {
   return (
     <footer className="bg-gray-50 border-t border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center">
+        <div className="text-center space-y-4">
+          <nav className="flex flex-wrap justify-center gap-4 text-sm">
+            <Link href="/about" className="text-gray-600 hover:text-gray-900">
+              {t.about}
+            </Link>
+            <Link href="/contact" className="text-gray-600 hover:text-gray-900">
+              {t.contact}
+            </Link>
+            <Link href="/privacy-policy" className="text-gray-600 hover:text-gray-900">
+              {t.privacyPolicy}
+            </Link>
+            <Link href="/terms-of-use" className="text-gray-600 hover:text-gray-900">
+              {t.termsOfUse}
+            </Link>
+            <Link href="/sitemap.xml" className="text-gray-600 hover:text-gray-900">
+              {t.sitemap}
+            </Link>
+          </nav>
           <p className="text-gray-600 text-sm">
             © {new Date().getFullYear()} {t.siteName}. {t.footerText}
           </p>
-          <p className="text-gray-500 text-xs mt-2">
+          <p className="text-gray-500 text-xs">
             {t.privacyText}
           </p>
         </div>

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -90,6 +90,9 @@ const EN_TRANSLATIONS = {
       tools: 'Tools',
       about: 'About',
       contact: 'Contact',
+      privacyPolicy: 'Privacy Policy',
+      termsOfUse: 'Terms of Use',
+      sitemap: 'Sitemap',
 
       // Hero Section
       heroTitle: 'Free Online Tools',
@@ -102,6 +105,11 @@ const EN_TRANSLATIONS = {
       allCategories: 'All',
       totalTools: 'Total:',
       toolsCounter: 'tools available',
+      // Footer
+      footerText: 'All rights reserved.',
+      privacyText: 'We use cookies to improve your experience.',
+      cookieMessage: 'This site uses cookies to ensure you get the best experience.',
+      acceptCookies: 'Accept',
       // Notepad
       notebookTitle: 'Notepad',
       notebookDescription: 'Write and save your notes quickly.',
@@ -299,6 +307,9 @@ export const getTranslations = () => {
       tools: 'Ferramentas',
       about: 'Sobre',
       contact: 'Contato',
+      privacyPolicy: 'Política de Privacidade',
+      termsOfUse: 'Termos de Uso',
+      sitemap: 'Mapa do Site',
       
       // Hero Section
       heroTitle: 'Ferramentas Online Gratuitas',
@@ -310,6 +321,11 @@ export const getTranslations = () => {
       allCategories: 'Todos',
       totalTools: 'Total:',
       toolsCounter: 'ferramentas disponíveis',
+      // Footer
+      footerText: 'Todos os direitos reservados.',
+      privacyText: 'Usamos cookies para melhorar sua experiência.',
+      cookieMessage: 'Este site utiliza cookies para garantir a melhor experiência.',
+      acceptCookies: 'Aceitar',
       // Bloco de Notas
       notebookTitle: 'Bloco de Notas',
       notebookDescription: 'Escreva e salve suas notas rapidamente.',


### PR DESCRIPTION
## Summary
- add cookie consent banner and sitemap link in footer
- add About, Contact, Privacy Policy and Terms of Use pages
- include static sitemap.xml and translations for new footer links

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_689a7cbf0c58832c8c9506d24729990b