### PR TITLE
Handle undefined language in tools data

### DIFF
--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -1037,12 +1037,14 @@ const toolsData = {
 
 export function getTools() {
   const language = getCurrentLanguage();
-  return toolsData[language].tools;
+  const langData = toolsData[language];
+  return langData ? langData.tools : toolsData['pt-BR'].tools;
 }
 
 export function getCategories() {
   const language = getCurrentLanguage();
-  return toolsData[language].categories;
+  const langData = toolsData[language];
+  return langData ? langData.categories : toolsData['pt-BR'].categories;
 }
 
 // Manter compatibilidade com código existente


### PR DESCRIPTION
## Summary
- prevent build-time crash by defaulting to Portuguese data when language key is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689a9d14be68832cbbca3d7cdecfda9a