### PR TITLE
refactor: reuse clipboard utility

### DIFF
--- a/src/app/lorem-ipsum/page.tsx
+++ b/src/app/lorem-ipsum/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Type, Copy, RotateCcw } from 'lucide-react';
 import { getTranslations } from '@/config/language';
+import { copyToClipboard as copyTextToClipboard } from '@/lib/utils';
 
 export default function LoremIpsumPage() {
   const t = getTranslations();
@@ -112,13 +113,11 @@ export default function LoremIpsumPage() {
     setGeneratedText(result);
   };
 
-  const copyToClipboard = async () => {
-    try {
-      await navigator.clipboard.writeText(generatedText);
+  const handleCopyToClipboard = async () => {
+    const success = await copyTextToClipboard(generatedText);
+    if (success) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Erro ao copiar:', err);
     }
   };
 
@@ -204,7 +203,7 @@ export default function LoremIpsumPage() {
             {generatedText && (
               <>
                 <button
-                  onClick={copyToClipboard}
+                  onClick={handleCopyToClipboard}
                   className={`px-6 py-2 rounded-lg transition-colors flex items-center gap-2 ${
                     copied ? 'bg-green-600 text-white' : 'bg-gray-600 text-white hover:bg-gray-700'
                   }`}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,31 +3,31 @@
  * Works in both secure and non-secure contexts
  */
 export const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined') {
+    console.error('Clipboard API not available');
+    return false;
+  }
+
   try {
     // Modern clipboard API (requires HTTPS)
     if (navigator.clipboard && window.isSecureContext) {
       await navigator.clipboard.writeText(text);
       return true;
-    } else {
-      // Fallback for older browsers or non-secure contexts
-      const textArea = document.createElement('textarea');
-      textArea.value = text;
-      textArea.style.position = 'fixed';
-      textArea.style.left = '-999999px';
-      textArea.style.top = '-999999px';
-      document.body.appendChild(textArea);
-      textArea.focus();
-      textArea.select();
-      
-      try {
-        const success = document.execCommand('copy');
-        document.body.removeChild(textArea);
-        return success;
-      } catch (err) {
-        document.body.removeChild(textArea);
-        throw err;
-      }
     }
+
+    // Fallback for older browsers or non-secure contexts
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-999999px';
+    textArea.style.top = '-999999px';
+    textArea.setAttribute('readonly', '');
+    document.body.appendChild(textArea);
+    textArea.select();
+
+    const success = document.execCommand('copy');
+    document.body.removeChild(textArea);
+    return success;
   } catch (err) {
     console.error('Failed to copy text:', err);
     return false;


### PR DESCRIPTION
## Summary
- improve clipboard utility with environment checks and simplified fallback
- use shared clipboard helper on lorem ipsum tool

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b31fed3b8832ca0495f448b8e3791