### PR TITLE
refactor: centralize pdf helpers

### DIFF
--- a/src/app/dividir-pdf/page.tsx
+++ b/src/app/dividir-pdf/page.tsx
@@ -5,6 +5,7 @@ import ToolLayout from '@/components/ToolLayout';
 import { Upload, FileText, Scissors, Split, Grid3X3 } from 'lucide-react';
 import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
+import { getPdfPageCount } from '@/lib/pdf';
 
 interface SplitMode {
   value: string;
@@ -62,24 +63,10 @@ export default function DividirPDFPage() {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  const getPageCount = async (file: File): Promise<number> => {
-    try {
-      const pdfjsLib = await import('pdfjs-dist');
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdf.worker.mjs';
-      
-      const arrayBuffer = await file.arrayBuffer();
-      const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
-      return pdf.numPages;
-    } catch (error) {
-      console.error('Erro ao contar páginas:', error);
-      return 0;
-    }
-  };
-
   const handleFileSelect = async (file: File) => {
     if (file.type === 'application/pdf') {
       setSelectedFile(file);
-      const pages = await getPageCount(file);
+      const pages = await getPdfPageCount(file);
       setPageCount(pages);
       setProgress(0);
       setCurrentPage(0);

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1,0 +1,26 @@
+import { PDFDocument } from 'pdf-lib';
+
+/**
+ * Get the number of pages in a PDF file
+ */
+export const getPdfPageCount = async (file: File): Promise<number> => {
+  const arrayBuffer = await file.arrayBuffer();
+  const pdfDoc = await PDFDocument.load(arrayBuffer);
+  return pdfDoc.getPageCount();
+};
+
+/**
+ * Merge multiple PDF files into a single PDF and return its bytes
+ */
+export const mergePdfFiles = async (files: File[]): Promise<Uint8Array> => {
+  const mergedPdf = await PDFDocument.create();
+
+  for (const file of files) {
+    const arrayBuffer = await file.arrayBuffer();
+    const pdfDoc = await PDFDocument.load(arrayBuffer);
+    const copiedPages = await mergedPdf.copyPages(pdfDoc, pdfDoc.getPageIndices());
+    copiedPages.forEach(page => mergedPdf.addPage(page));
+  }
+
+  return mergedPdf.save();
+};


### PR DESCRIPTION
## Summary
- add shared pdf utilities for page count and merging
- refactor merge and split pdf tools to use helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b4d290bac832c8e9e3d3fa3c8b8ab