### PR TITLE
refactor: centralize pdf file validation

### DIFF
--- a/src/app/compare-pdf/page.tsx
+++ b/src/app/compare-pdf/page.tsx
@@ -5,6 +5,7 @@ import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, Eye, Trash2, AlertCircle, CheckCircle, GitCompare, ArrowRight } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
 import { getTranslations } from '@/config/language';
+import { isPdfFile } from '@/lib/pdf';
 
 interface ComparisonResult {
   fileName: string;
@@ -65,7 +66,7 @@ export default function ComparePdfPage() {
   };
 
   const handleFileSelect = (selectedFile: File, fileNumber: 1 | 2) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert(t.comparePdf?.onlyPdfAlert || 'Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/crop-pdf/page.tsx
+++ b/src/app/crop-pdf/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, Crop, CheckCircle, AlertTriangle, Scissors, Eye, RotateCcw } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
+import { isPdfFile } from '@/lib/pdf';
 
 interface CropSettings {
   top: number;
@@ -93,7 +94,7 @@ export default function CropPdfPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/extract-assets/page.tsx
+++ b/src/app/extract-assets/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, Image, Package, CheckCircle, AlertTriangle, Settings, Archive } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
+import { isPdfFile } from '@/lib/pdf';
 
 interface ExtractedAsset {
   type: 'image' | 'font' | 'metadata' | 'text';
@@ -172,7 +173,7 @@ export default function ExtractAssetsPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/pdf-to-ppt/page.tsx
+++ b/src/app/pdf-to-ppt/page.tsx
@@ -5,6 +5,7 @@ import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, CheckCircle, AlertTriangle, Presentation, RefreshCw, Settings, Image, FileImage } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
 import { getTranslations } from '@/config/language';
+import { isPdfFile } from '@/lib/pdf';
 
 interface ConversionSettings {
   slideLayout: 'single' | 'multiple';
@@ -82,7 +83,7 @@ export default function PdfToPptPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert(t.pdfToPpt?.onlyPdfAlert || 'Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/pdf-to-speech/page.tsx
+++ b/src/app/pdf-to-speech/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Play, Pause, Square, Volume2, FileText, Upload, Download, Settings } from 'lucide-react';
+import { isPdfFile } from '@/lib/pdf';
 
 interface Voice {
   name: string;
@@ -59,7 +60,7 @@ export default function PdfToSpeechPage() {
   // Extrair texto de PDF
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (!file || file.type !== 'application/pdf') {
+    if (!isPdfFile(file)) {
       alert('Por favor, selecione um arquivo PDF válido.');
       return;
     }

--- a/src/app/remove-assets/page.tsx
+++ b/src/app/remove-assets/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, Image, Trash2, CheckCircle, AlertTriangle, Settings } from 'lucide-react';
 import { PDFDocument, PDFPage } from 'pdf-lib';
+import { isPdfFile } from '@/lib/pdf';
 
 interface AssetInfo {
   type: 'image' | 'form' | 'annotation' | 'font' | 'other';
@@ -131,7 +132,7 @@ export default function RemoveAssetsPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/repair-pdf/page.tsx
+++ b/src/app/repair-pdf/page.tsx
@@ -5,6 +5,7 @@ import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, AlertTriangle, CheckCircle, Wrench, Trash2, Info, Shield } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
 import { getTranslations } from '@/config/language';
+import { isPdfFile } from '@/lib/pdf';
 
 interface RepairResult {
   fileName: string;
@@ -62,7 +63,7 @@ export default function RepairPdfPage() {
   };
 
   const handleFileSelect = (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/rotate-pages/page.tsx
+++ b/src/app/rotate-pages/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, RotateCw, RotateCcw, CheckCircle, AlertTriangle, RefreshCw, Eye } from 'lucide-react';
 import { PDFDocument, degrees } from 'pdf-lib';
+import { isPdfFile } from '@/lib/pdf';
 
 interface PageRotation {
   pageNumber: number;
@@ -83,7 +84,7 @@ export default function RotatePagesPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/searchable-pdf/page.tsx
+++ b/src/app/searchable-pdf/page.tsx
@@ -5,6 +5,7 @@ import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, Eye, Trash2, AlertCircle, CheckCircle, Search } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
 import Tesseract from 'tesseract.js';
+import { isPdfFile } from '@/lib/pdf';
 
 interface SearchablePdf {
   fileName: string;
@@ -49,7 +50,7 @@ export default function SearchablePdfPage() {
   };
 
   const handleFileSelect = (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/app/sort-pages/page.tsx
+++ b/src/app/sort-pages/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import ToolLayout from '@/components/ToolLayout';
 import { Upload, Download, FileText, ArrowUp, ArrowDown, Trash2, RotateCcw, Move, CheckCircle } from 'lucide-react';
 import { PDFDocument } from 'pdf-lib';
+import { isPdfFile } from '@/lib/pdf';
 
 interface PageInfo {
   pageNumber: number;
@@ -43,7 +44,7 @@ export default function SortPagesPage() {
   };
 
   const handleFileSelect = async (selectedFile: File) => {
-    if (selectedFile.type !== 'application/pdf') {
+    if (!isPdfFile(selectedFile)) {
       alert('Por favor, selecione apenas arquivos PDF.');
       return;
     }

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1,6 +1,13 @@
 import { PDFDocument } from 'pdf-lib';
 
 /**
+ * Check if a provided file is a valid PDF
+ */
+export const isPdfFile = (file?: File | null): boolean => {
+  return !!file && file.type === 'application/pdf';
+};
+
+/**
  * Get the number of pages in a PDF file
  */
 export const getPdfPageCount = async (file: File): Promise<number> => {


### PR DESCRIPTION
## Summary
- add reusable `isPdfFile` helper for consistent PDF validation
- update PDF tools to use the shared check instead of manual MIME comparisons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/lib/pdf.ts src/app/repair-pdf/page.tsx src/app/crop-pdf/page.tsx src/app/searchable-pdf/page.tsx src/app/rotate-pages/page.tsx src/app/pdf-to-speech/page.tsx src/app/sort-pages/page.tsx src/app/extract-assets/page.tsx src/app/remove-assets/page.tsx src/app/pdf-to-ppt/page.tsx src/app/compare-pdf/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b58e2dda0832c881834263d96956d