### PR TITLE
Add localized category labels for tool filters

### DIFF
--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -11,7 +11,7 @@ const t = getTranslations();
 
 export default function ToolsPage() {
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState('All');
+  const [selectedCategory, setSelectedCategory] = useState(t.allCategories);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [showFilters, setShowFilters] = useState(false);
 
@@ -20,7 +20,8 @@ export default function ToolsPage() {
     return tools.filter(tool => {
       const matchesSearch = tool.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
                            tool.description.toLowerCase().includes(searchTerm.toLowerCase());
-      const matchesCategory = selectedCategory === 'All' || tool.category === selectedCategory;
+      const matchesCategory =
+        selectedCategory === t.allCategories || tool.category === selectedCategory;
       return matchesSearch && matchesCategory;
     });
   }, [searchTerm, selectedCategory]);
@@ -120,16 +121,16 @@ export default function ToolsPage() {
               <h3 className="text-sm font-semibold text-gray-700 mb-3">Categorias</h3>
               <div className="flex flex-wrap gap-2">
                 <button
-                  onClick={() => setSelectedCategory('All')}
+                  onClick={() => setSelectedCategory(t.allCategories)}
                   className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                    selectedCategory === 'All'
+                    selectedCategory === t.allCategories
                       ? 'bg-blue-600 text-white shadow-lg'
                       : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                   }`}
                 >
-                  Todas ({tools.length})
+                  {t.allCategories} ({tools.length})
                 </button>
-                {categories.filter(cat => cat !== 'All').map((category) => (
+                {categories.slice(1).map((category) => (
                   <button
                     key={category}
                     onClick={() => setSelectedCategory(category)}
@@ -148,7 +149,7 @@ export default function ToolsPage() {
         </div>
 
         {/* Categorias Populares */}
-        {searchTerm === '' && selectedCategory === 'All' && (
+        {searchTerm === '' && selectedCategory === t.allCategories && (
           <div className="mb-8">
             <h2 className="text-2xl font-bold text-gray-800 mb-4">📈 Categorias Populares</h2>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -176,7 +177,9 @@ export default function ToolsPage() {
         <div className="mb-6">
           <div className="flex items-center justify-between">
             <h2 className="text-xl font-semibold text-gray-800">
-              {selectedCategory === 'All' ? 'Todas as Ferramentas' : selectedCategory}
+              {selectedCategory === t.allCategories
+                ? `${t.allCategories} ${t.tools}`
+                : selectedCategory}
               <span className="text-gray-500 ml-2">({filteredTools.length})</span>
             </h2>
             {searchTerm && (
@@ -218,7 +221,7 @@ export default function ToolsPage() {
             <button
               onClick={() => {
                 setSearchTerm('');
-                setSelectedCategory('All');
+                setSelectedCategory(t.allCategories);
               }}
               className="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors"
             >

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -32,7 +32,7 @@ import {
   Archive,
   Plus
 } from 'lucide-react';
-import { getCurrentLanguage } from '@/config/language';
+import { getCurrentLanguage, Language } from '@/config/language';
 
 // Dados das ferramentas movidos para toolsData abaixo
 
@@ -520,19 +520,6 @@ const toolsData = {
         icon: DollarSign,
         category: 'Financeiro'
       }
-    ],
-    categories: [
-      'Todos',
-      'Áudio/Vídeo',
-      'PDF',
-      'Imagem',
-      'QR Code',
-      'Segurança',
-      'Web',
-      'Utilidades',
-      'Texto',
-      'Financeiro',
-      'Internet'
     ]
   },
   'en': {
@@ -1018,21 +1005,141 @@ const toolsData = {
         icon: DollarSign,
         category: 'Financial'
       }
-    ],
-    categories: [
-      'All',
-      'Audio/Video',
-      'PDF',
-      'Image',
-      'QR Code',
-      'Security',
-      'Web',
-      'Utilities',
-      'Text',
-      'Financial',
-      'Internet'
     ]
   }
+};
+
+const categoriesData: Record<Language, string[]> = {
+  'pt-BR': [
+    'Todos',
+    'Áudio/Vídeo',
+    'PDF',
+    'Imagem',
+    'QR Code',
+    'Segurança',
+    'Web',
+    'Utilidades',
+    'Texto',
+    'Financeiro',
+    'Internet'
+  ],
+  en: [
+    'All',
+    'Audio/Video',
+    'PDF',
+    'Image',
+    'QR Code',
+    'Security',
+    'Web',
+    'Utilities',
+    'Text',
+    'Financial',
+    'Internet'
+  ],
+  es: [
+    'Todos',
+    'Audio/Video',
+    'PDF',
+    'Imagen',
+    'Código QR',
+    'Seguridad',
+    'Web',
+    'Utilidades',
+    'Texto',
+    'Financiero',
+    'Internet'
+  ],
+  zh: [
+    '全部',
+    '音频/视频',
+    'PDF',
+    '图像',
+    '二维码',
+    '安全',
+    '网络',
+    '实用工具',
+    '文本',
+    '金融',
+    '互联网'
+  ],
+  hi: [
+    'सभी',
+    'ऑडियो/वीडियो',
+    'PDF',
+    'छवि',
+    'QR कोड',
+    'सुरक्षा',
+    'वेब',
+    'उपयोगिताएँ',
+    'पाठ',
+    'वित्तीय',
+    'इंटरनेट'
+  ],
+  ar: [
+    'الكل',
+    'صوت/فيديو',
+    'PDF',
+    'صورة',
+    'رمز QR',
+    'أمان',
+    'ويب',
+    'أدوات',
+    'نص',
+    'مالي',
+    'إنترنت'
+  ],
+  bn: [
+    'সব',
+    'অডিও/ভিডিও',
+    'PDF',
+    'চিত্র',
+    'QR কোড',
+    'নিরাপত্তা',
+    'ওয়েব',
+    'ইউটিলিটি',
+    'টেক্সট',
+    'আর্থিক',
+    'ইন্টারনেট'
+  ],
+  ru: [
+    'Все',
+    'Аудио/Видео',
+    'PDF',
+    'Изображение',
+    'QR код',
+    'Безопасность',
+    'Веб',
+    'Утилиты',
+    'Текст',
+    'Финансы',
+    'Интернет'
+  ],
+  ja: [
+    'すべて',
+    'オーディオ/ビデオ',
+    'PDF',
+    '画像',
+    'QRコード',
+    'セキュリティ',
+    'ウェブ',
+    'ユーティリティ',
+    'テキスト',
+    '金融',
+    'インターネット'
+  ],
+  de: [
+    'Alle',
+    'Audio/Video',
+    'PDF',
+    'Bild',
+    'QR-Code',
+    'Sicherheit',
+    'Web',
+    'Dienstprogramme',
+    'Text',
+    'Finanzen',
+    'Internet'
+  ]
 };
 
 export function getTools() {
@@ -1043,8 +1150,7 @@ export function getTools() {
 
 export function getCategories() {
   const language = getCurrentLanguage();
-  const langData = toolsData[language];
-  return langData ? langData.categories : toolsData['pt-BR'].categories;
+  return categoriesData[language] || categoriesData['pt-BR'];
 }
 
 // Manter compatibilidade com código existente


### PR DESCRIPTION
## Summary
- add translations for tool categories across supported languages
- use localized "All" label and translated category list on tools page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b5a559cec832cb4e41f3d21886e26