### PR TITLE
Remove brand from Portuguese home tagline

### DIFF
--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -282,8 +282,8 @@ const EN_TRANSLATIONS = {
 // pt-BR (com páginas e navegação + chaves adicionais)
 const PT_BR = {
   // Site Meta
-  siteTitle: 'NICOLLAUTOOLS - Ferramentas Online Gratuitas',
-    siteName: 'NICOLLAUTOOLS',
+  siteTitle: 'Ferramentas Online Gratuitas',
+  siteName: 'NICOLLAUTOOLS',
   siteDescription:
     'Acesse uma coleção completa de ferramentas online gratuitas para PDF, conversão de vídeo, geração de QR codes e muito mais.',
 
@@ -305,7 +305,7 @@ const PT_BR = {
   aboutPageKeywords: ['sobre', 'ferramentas online', 'informações'],
 
   // Hero Section
-  heroTitle: 'NICOLLAUTOOLS - Ferramentas Online Gratuitas',
+  heroTitle: 'Ferramentas Online Gratuitas',
   heroSubtitle: 'Tudo que você precisa em um só lugar',
   heroDescription:
     'Acesse uma coleção completa de ferramentas online gratuitas para facilitar seu trabalho e aumentar sua produtividade.',


### PR DESCRIPTION
## Summary
- strip NICOLLAUTOOLS name from Portuguese site and hero titles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint found errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689bc31b7364832ca441e7e577d2e706