### PR TITLE
feat: add configurable Google AdSense meta tag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ NEXT_PUBLIC_DEFAULT_LANGUAGE=pt-BR
 
 # Base site URL for generating canonical links
 NEXT_PUBLIC_SITE_URL=
+
+# Google AdSense account ID
+NEXT_PUBLIC_GOOGLE_ADSENSE_ACCOUNT=ca-pub-5353841428111098

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,10 +13,14 @@ const inter = Inter({
 
 const t = getTranslations();
 const lang = getCurrentLanguage();
+const adsenseAccount = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_ACCOUNT;
 
 export const metadata: Metadata = {
   title: t.siteTitle,
   description: t.siteDescription,
+  other: adsenseAccount
+    ? { "google-adsense-account": adsenseAccount }
+    : undefined,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- allow configuring Google AdSense account via env variable
- inject Google AdSense meta tag dynamically in layout

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/app/layout.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689bc4b6d574832cbb1c7335e1d73c4c