### PR TITLE
feat: make sitemap dynamic per domain

### DIFF
--- a/src/app/api/sitemap-stats/route.ts
+++ b/src/app/api/sitemap-stats/route.ts
@@ -51,13 +51,6 @@ function detectLanguageFromRequest(request: NextRequest): string {
 
 // Função para obter a URL base do request
 function getSiteUrl(request: NextRequest): string {
-  // Tentar obter da variável de ambiente primeiro
-  const envUrl = process.env.NEXT_PUBLIC_SITE_URL
-  if (envUrl && envUrl !== 'http://localhost:3000') {
-    return envUrl
-  }
-  
-  // Se não houver ou for localhost, usar a URL do request
   const url = new URL(request.url)
   return `${url.protocol}//${url.host}`
 }

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -55,20 +55,9 @@ function detectLanguageFromRequest(request: NextRequest): string {
 
 // Função para obter a URL base do request
 function getSiteUrl(request: NextRequest): string {
-  // Sempre usar a URL do request para garantir URL dinâmica
   const url = new URL(request.url)
-  const dynamicUrl = `${url.protocol}//${url.host}`
-  
-  // Só usar variável de ambiente se não for localhost e estiver definida
-  const envUrl = process.env.NEXT_PUBLIC_SITE_URL
-  if (envUrl && envUrl.trim() !== '' && !envUrl.includes('localhost')) {
-    return envUrl
-  }
-  
-  return dynamicUrl
+  return `${url.protocol}//${url.host}`
 }
-
-const FALLBACK_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
 // Configuração de prioridades e frequências para SEO otimizado
 const sitemapConfig = {
@@ -317,9 +306,8 @@ export async function GET(request: NextRequest) {
 }
 
 // Função para obter estatísticas do sitemap (usada pela API)
-export function getSitemapStats(siteUrl?: string, language?: string) {
-  const fallbackUrl = siteUrl || FALLBACK_SITE_URL
-  const detectedLanguage = language || 'pt-BR'
+export function getSitemapStats(siteUrl = 'http://localhost:3000', language = 'pt-BR') {
+  const detectedLanguage = language
   
   // Coletar todas as URLs
   const allUrls: Array<{
@@ -332,7 +320,7 @@ export function getSitemapStats(siteUrl?: string, language?: string) {
   Object.entries(sitemapConfig).forEach(([categoryName, config]) => {
     config.routes.forEach(route => {
       allUrls.push({
-        url: `${fallbackUrl}${route}`,
+        url: `${siteUrl}${route}`,
         priority: config.priority,
         changefreq: config.changeFreq,
         category: categoryName
@@ -358,7 +346,7 @@ export function getSitemapStats(siteUrl?: string, language?: string) {
     totalRoutes,
     categoriesCount,
     priorityDistribution,
-    siteUrl: fallbackUrl,
+    siteUrl,
     detectedLanguage,
     availableLanguages,
     supportedLanguages,


### PR DESCRIPTION
## Summary
- ensure sitemap.xml always uses request host for URLs
- remove static site URL fallback from sitemap stats API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*


------
https://chatgpt.com/codex/tasks/task_e_689e68663db8832c946c1d40181273a5