### PR TITLE
Fix sitemap URL generation for proxied requests

### DIFF
--- a/src/app/api/sitemap-stats/route.ts
+++ b/src/app/api/sitemap-stats/route.ts
@@ -27,9 +27,9 @@ const subdomainToLanguage: Record<string, string> = {
 
 // Função para detectar idioma baseado no subdomínio
 function detectLanguageFromRequest(request: NextRequest): string {
-  // Primeiro tenta obter do header Host (para testes e proxies)
-  const hostHeader = request.headers.get('host');
-  let hostname = hostHeader || request.nextUrl.hostname;
+  // Primeiro tenta obter do header X-Forwarded-Host ou Host (para proxies)
+  const hostHeader = request.headers.get('x-forwarded-host') || request.headers.get('host')
+  let hostname = hostHeader || request.nextUrl.hostname
   
   // Remove a porta se presente
   hostname = hostname.split(':')[0];
@@ -52,7 +52,9 @@ function detectLanguageFromRequest(request: NextRequest): string {
 // Função para obter a URL base do request
 function getSiteUrl(request: NextRequest): string {
   const url = new URL(request.url)
-  return `${url.protocol}//${url.host}`
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host') || url.host
+  const protocol = request.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  return `${protocol}://${host}`
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -26,9 +26,9 @@ const subdomainToLanguage: Record<string, string> = {
 
 // Função para detectar idioma baseado no subdomínio
 function detectLanguageFromRequest(request: NextRequest): string {
-  // Primeiro tenta obter do header Host (para testes e proxies)
-  const hostHeader = request.headers.get('host');
-  let hostname = hostHeader || request.nextUrl.hostname;
+  // Primeiro tenta obter do header X-Forwarded-Host ou Host (para proxies)
+  const hostHeader = request.headers.get('x-forwarded-host') || request.headers.get('host')
+  let hostname = hostHeader || request.nextUrl.hostname
   
   // Remove a porta se presente
   hostname = hostname.split(':')[0];
@@ -52,14 +52,16 @@ function detectLanguageFromRequest(request: NextRequest): string {
 function getSiteUrl(request: NextRequest): string {
   // Sempre usar a URL do request para garantir URL dinâmica
   const url = new URL(request.url)
-  const dynamicUrl = `${url.protocol}//${url.host}`
-  
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host') || url.host
+  const protocol = request.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  const dynamicUrl = `${protocol}://${host}`
+
   // Só usar variável de ambiente se não for localhost e estiver definida
   const envUrl = process.env.NEXT_PUBLIC_SITE_URL
   if (envUrl && envUrl.trim() !== '' && !envUrl.includes('localhost')) {
     return envUrl
   }
-  
+
   return dynamicUrl
 }
 

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -31,9 +31,9 @@ const subdomainToLanguage: Record<string, string> = {
 
 // Função para detectar idioma baseado no subdomínio
 function detectLanguageFromRequest(request: NextRequest): string {
-  // Primeiro tenta obter do header Host (para testes e proxies)
-  const hostHeader = request.headers.get('host');
-  let hostname = hostHeader || request.nextUrl.hostname;
+  // Primeiro tenta obter do header X-Forwarded-Host ou Host (para proxies)
+  const hostHeader = request.headers.get('x-forwarded-host') || request.headers.get('host')
+  let hostname = hostHeader || request.nextUrl.hostname
   
   // Remove a porta se presente
   hostname = hostname.split(':')[0];
@@ -56,7 +56,9 @@ function detectLanguageFromRequest(request: NextRequest): string {
 // Função para obter a URL base do request
 function getSiteUrl(request: NextRequest): string {
   const url = new URL(request.url)
-  return `${url.protocol}//${url.host}`
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host') || url.host
+  const protocol = request.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  return `${protocol}://${host}`
 }
 
 // Configuração de prioridades e frequências para SEO otimizado


### PR DESCRIPTION
## Summary
- use `x-forwarded-*` headers to detect language and site URL in sitemap and stats routes
- respect forwarded headers when building robots.txt

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e6db7b184832c943eeff026d02b85